### PR TITLE
Release: 2.1.0-beta1

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,10 +1,11 @@
 name: Validate with hassfest
 
 on:
-  push:
-  pull_request:
-  schedule:
-    - cron: "0 0 * * *"
+  workflow_dispatch:
+#  push:
+#  pull_request:
+#  schedule:
+#    - cron: "0 0 * * *"
 
 jobs:
   validate:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,10 +1,11 @@
 name: Validate
 
 on:
-  push:
-  pull_request:
-  schedule:
-    - cron: "0 0 * * *"
+  workflow_dispatch:
+#  push:
+#  pull_request:
+#  schedule:
+#    - cron: "0 0 * * *"
 
 jobs:
   validate:

--- a/README.md
+++ b/README.md
@@ -1,25 +1,53 @@
-# HASS.Agent Integration
+# HASS.Agent 2 Integration - Media Player & Notifications
 
-This <a href="https://www.home-assistant.io" target="_blank">Home Assistant</a> integration is the second-half of <a href="https://github.com/hass-agent/HASS.Agent" target="_blank">HASS.Agent</a>, a Windows-based Home Assistant client. This integration allows HASS.Agent to add entities, provide helpers to send notifications to the HASS.Agent PC and provide a media player. 
+### Notice
+
+This integration is intended to work with <a href="https://github.com/hass-agent/HASS.Agent" target="_blank">forked version of HASS.Agent</a>.
+
+While it's **very likely** that it'll also work with the original version, it cannot be guaranteed.
+
+----
+
+## Description
+
+This <a href="https://www.home-assistant.io" target="_blank">Home Assistant</a> integration is the second-half of <a href="https://github.com/hass-agent/HASS.Agent" target="_blank">HASS.Agent</a>, a Windows-based Home Assistant client.
+
+This integration allows HASS.Agent to act as a media player and notification receiver (like Home Assistant Companion Applications). 
 
 All communication is done through MQTT. It supports auto discovery, so you'll see your HASS.Agent devices show up automatically in the integrations page:
 
 ![image](https://user-images.githubusercontent.com/81011038/198246059-caa7f1cd-89f7-41f9-989e-724a1a67c2fe.png)
 
-The new mediaplayer has a bunch of new features, like coverart:
+## Features
+Windows device acting as a media player (for music and TTS messages):
 
 ![image](https://user-images.githubusercontent.com/81011038/198246217-cce288be-bbb7-4c5f-baff-510cc99c30b1.png)
 
-You can use actionable notifications to interact with HA:
+Sending interactable notifications:
 
 ![image](https://user-images.githubusercontent.com/81011038/190643738-724dac45-4d03-4a19-a0e6-3a59b5de0aad.png)
+
+## Installation
+
+The supported way to install HASS.Agent integration is through HACS. This version of is ***not yet available in HACS by default and needs to be added as a custom repository***.
+
+If you have the **original version of HASS.Agent integration** installed (either version), **please remove it** before proceeding further and restart Home Assistant.
+
+1. Add "HASS.Agent 2 Integration" repository - https://github.com/hass-agent/HASS.Agent-Integration - as a custom HACS integration repository.
+ ![i0mENM](https://github.com/amadeo-alex/HASS.Agent-Integration/assets/68441479/13e0f132-9b01-46f0-97c9-05f33f214aaf)
+ <img src="https://github.com/amadeo-alex/HASS.Agent-Integration/assets/68441479/438a0dd7-975f-4cf3-a138-887fd4cf9eee" width="300" />
+
+3. Install "HASS.Agent 2 Integration" from HACS (including restart), as you would with any other integration.
+4. Configure HASS.Agent devices when they are discovered.
+
+In case of issues please get in touch <a href="https://discord.gg/JfZj98xqJr" target="_blank">on Discord</a>.
 
 ----
 
 [GETTING STARTED GUIDE](https://www.hass-agent.io/latest/getting-started/)
 
-For more help and examples, check [the documentation](https://www.hass-agent.io/latest/), visit the <a href="https://community.home-assistant.io/t/hass-agent-a-new-windows-based-client-to-receive-notifications-perform-quick-actions-and-much-more/369094" target="_blank">dedicated HA forum thread</a> or <a href="https://discord.gg/JfZj98xqJr" target="_blank">join on Discord</a>.
+For more help and examples, check [the documentation](https://www.hass-agent.io/latest/), <a href="https://discord.gg/JfZj98xqJr" target="_blank">join on Discord</a> or visit the <a href="https://community.home-assistant.io/t/hass-agent-a-new-windows-based-client-to-receive-notifications-perform-quick-actions-and-much-more/369094" target="_blank">dedicated HA forum thread (for original version)</a>.
 
 ----
 
-Thanks [@fillefilip8](https://github.com/fillefilip8) for developing!
+Thanks [@fillefilip8](https://github.com/fillefilip8) for developing the original version!

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ The supported way to install HASS.Agent integration is through HACS. This versio
 If you have the **original version of HASS.Agent integration** installed (either version), **please remove it** before proceeding further and restart Home Assistant.
 
 1. Add "HASS.Agent 2 Integration" repository - https://github.com/hass-agent/HASS.Agent-Integration - as a custom HACS integration repository.
- ![i0mENM](https://github.com/amadeo-alex/HASS.Agent-Integration/assets/68441479/13e0f132-9b01-46f0-97c9-05f33f214aaf)
- <img src="https://github.com/amadeo-alex/HASS.Agent-Integration/assets/68441479/438a0dd7-975f-4cf3-a138-887fd4cf9eee" width="300" />
+ ![i0mENM](https://github.com/amadeo-alex/HASS.Agent-Integration/assets/68441479/13e0f132-9b01-46f0-97c9-05f33f214aaf) <img src="https://github.com/amadeo-alex/HASS.Agent-Integration/assets/68441479/438a0dd7-975f-4cf3-a138-887fd4cf9eee" width="300" />
 
 3. Install "HASS.Agent 2 Integration" from HACS (including restart), as you would with any other integration.
 4. Configure HASS.Agent devices when they are discovered.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Windows device acting as a media player (for music and TTS messages):
 
 ![image](https://user-images.githubusercontent.com/81011038/198246217-cce288be-bbb7-4c5f-baff-510cc99c30b1.png)
 
-Sending interactable notifications:
+Sending actionable notifications:
 
 ![image](https://user-images.githubusercontent.com/81011038/190643738-724dac45-4d03-4a19-a0e6-3a59b5de0aad.png)
 

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -83,6 +83,7 @@ async def async_wait_for_mqtt_client(hass: HomeAssistant) -> bool:
         return False
 
 async def handle_apis_changed(hass: HomeAssistant, entry: ConfigEntry, apis):
+    _logger.debug("api changed for: %s", entry.entry_id)
     if apis is not None:
 
         device_registry = dr.async_get(hass)
@@ -142,6 +143,8 @@ async def handle_apis_changed(hass: HomeAssistant, entry: ConfigEntry, apis):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up HASS.Agent from a config entry."""
+
+    _logger.debug("setting up device from config entry: %s", entry.entry_id)
 
     hass.data.setdefault(DOMAIN, {})
 
@@ -214,6 +217,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
 
+    _logger.debug("unloading device: %s", entry.entry_id)
+
     # known issue: notify does not always unload
 
     loaded = hass.data[DOMAIN][entry.entry_id].get("loaded", None)
@@ -249,6 +254,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up hass_agent integration."""
+
+    _logger.debug("integration setup start")
+
     hass.http.register_view(MediaPlayerThumbnailView(hass))
 
     # Make sure MQTT integration is enabled and the client is available

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -40,7 +40,7 @@ FOLDER = "hass_agent"
 
 PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
 
-_LOGGER = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 async def update_device_info(hass: HomeAssistant, entry: ConfigEntry, new_device_info):
     device_registry = dr.async_get(hass)
@@ -253,12 +253,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     # Make sure MQTT integration is enabled and the client is available
     if not await mqtt.async_wait_for_mqtt_client(hass):
-        _LOGGER.error("MQTT integration is not available")
+        _logger.error("MQTT integration is not available")
         return False
     
     async def _handle_reload(service):
         """Handle reload service call."""
-        _LOGGER.info("Service %s.reload called: reloading integration", DOMAIN)
+        _logger.info("Service %s.reload called: reloading integration", DOMAIN)
 
         current_entries = hass.config_entries.async_entries(DOMAIN)
 

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -253,23 +253,23 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _logger.error("MQTT integration is not available")
         return False
     
-    async def _handle_reload(service):
-        """Handle reload service call."""
-        _logger.info("Service %s.reload called: reloading integration", DOMAIN)
+    # async def _handle_reload(service):
+    #     """Handle reload service call."""
+    #     _logger.info("Service %s.reload called: reloading integration", DOMAIN)
 
-        current_entries = hass.config_entries.async_entries(DOMAIN)
+    #     current_entries = hass.config_entries.async_entries(DOMAIN)
 
-        reload_tasks = [
-            hass.config_entries.async_reload(entry.entry_id)
-            for entry in current_entries
-        ]
+    #     reload_tasks = [
+    #         hass.config_entries.async_reload(entry.entry_id)
+    #         for entry in current_entries
+    #     ]
 
-        await asyncio.gather(*reload_tasks)
+    #     await asyncio.gather(*reload_tasks)
 
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_RELOAD,
-        _handle_reload,
-    )
+    # hass.services.async_register(
+    #     DOMAIN,
+    #     SERVICE_RELOAD,
+    #     _handle_reload,
+    # )
 
     return True

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -272,7 +272,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         await asyncio.gather(*reload_tasks)
 
-    hass.helpers.service.async_register_admin_service(
+    async_register_admin_service(
         DOMAIN,
         SERVICE_RELOAD,
         _handle_reload,

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -83,7 +83,7 @@ async def async_wait_for_mqtt_client(hass: HomeAssistant) -> bool:
         return False
 
 async def handle_apis_changed(hass: HomeAssistant, entry: ConfigEntry, apis):
-    _logger.debug("api changed for: %s", entry.entry_id)
+    _logger.debug("api changed for: %s", entry.unique_id)
     if apis is not None:
 
         device_registry = dr.async_get(hass)
@@ -92,15 +92,10 @@ async def handle_apis_changed(hass: HomeAssistant, entry: ConfigEntry, apis):
         )
 
         media_player = apis.get("media_player", False)
-        is_media_player_loaded = hass.data[DOMAIN][entry.entry_id]["loaded"][
-            "media_player"
-        ]
+        is_media_player_loaded = hass.data[DOMAIN][entry.entry_id]["loaded"]["media_player"]
 
         notifications = apis.get("notifications", False)
-
-        is_notifications_loaded = hass.data[DOMAIN][entry.entry_id]["loaded"][
-            "notifications"
-        ]
+        is_notifications_loaded = hass.data[DOMAIN][entry.entry_id]["loaded"]["notifications"]
 
         if media_player and is_media_player_loaded is False:
             _logger.debug("loading media_player for device: %s", device.name)

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -270,11 +270,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         await asyncio.gather(*reload_tasks)
 
-    async_register_admin_service(
-        hass,
-        DOMAIN,
-        SERVICE_RELOAD,
-        _handle_reload,
-    )
+    # async_register_admin_service(
+    #     hass,
+    #     DOMAIN,
+    #     SERVICE_RELOAD,
+    #     _handle_reload,
+    # )
 
     return True

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -98,13 +98,13 @@ async def handle_apis_changed(hass: HomeAssistant, entry: ConfigEntry, apis):
         is_notifications_loaded = hass.data[DOMAIN][entry.entry_id]["loaded"]["notifications"]
 
         if media_player and is_media_player_loaded is False:
-            _logger.debug("loading media_player for device: %s [%s]", device.name, device.serial_number)
+            _logger.debug("loading media player for device: %s [%s]", device.name, entry.unique_id)
             await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
             hass.data[DOMAIN][entry.entry_id]["loaded"]["media_player"] = True
         else:
             if is_media_player_loaded:
-                _logger.debug("unloading media_player for device: %s [%s]", device.name, device.serial_number)
+                _logger.debug("unloading media player for device: %s [%s]", device.name, entry.unique_id)
                 await hass.config_entries.async_forward_entry_unload(
                     entry, Platform.MEDIA_PLAYER
                 )
@@ -112,7 +112,7 @@ async def handle_apis_changed(hass: HomeAssistant, entry: ConfigEntry, apis):
                 hass.data[DOMAIN][entry.entry_id]["loaded"]["media_player"] = False
 
         if notifications and is_notifications_loaded is False:
-            _logger.debug("loading notify for device: %s [%s]", device.name, device.serial_number)
+            _logger.debug("loading notifications for device: %s [%s]", device.name, entry.unique_id)
 
             hass.async_create_task(
                 discovery.async_load_platform(
@@ -126,7 +126,7 @@ async def handle_apis_changed(hass: HomeAssistant, entry: ConfigEntry, apis):
             hass.data[DOMAIN][entry.entry_id]["loaded"]["notifications"] = True
         else:
             if is_notifications_loaded:
-                _logger.debug("unloading notify for device: %s [%s]", device.name, device.serial_number)
+                _logger.debug("unloading notifications for device: %s [%s]", device.name, entry.unique_id)
                 await hass.config_entries.async_unload_platforms(
                     entry, [Platform.NOTIFY]
                 )

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -271,6 +271,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await asyncio.gather(*reload_tasks)
 
     async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_RELOAD,
         _handle_reload,

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -29,7 +29,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback, ServiceCall, async_get_hass
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import discovery
-from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify    
 
@@ -270,11 +269,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         await asyncio.gather(*reload_tasks)
 
-    # async_register_admin_service(
-    #     hass,
-    #     DOMAIN,
-    #     SERVICE_RELOAD,
-    #     _handle_reload,
-    # )
+    hass.services.async_register(
+        hass,
+        DOMAIN,
+        SERVICE_RELOAD,
+        _handle_reload,
+    )
 
     return True

--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -34,9 +34,6 @@ from homeassistant.util import slugify
 
 from .const import DOMAIN
 
-DOMAIN = "hass_agent"
-FOLDER = "hass_agent"
-
 PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
 
 _logger = logging.getLogger(__name__)
@@ -270,7 +267,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await asyncio.gather(*reload_tasks)
 
     hass.services.async_register(
-        hass,
         DOMAIN,
         SERVICE_RELOAD,
         _handle_reload,

--- a/custom_components/hass_agent/config_flow.py
+++ b/custom_components/hass_agent/config_flow.py
@@ -81,6 +81,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._data = {"device": payload["device"], "apis": payload["apis"]}
 
         for config in self._async_current_entries():
+            _logger.debug("device: %s, SN: %s, UID: %s", device_name, serial_number, config.unique_id) # TODO(Amadeo): remove
             if config.unique_id == serial_number:
                 _logger.debug("device %s, serial number: %s already configured, ignoring", device_name, serial_number)
                 return self.async_abort(reason="already_configured")

--- a/custom_components/hass_agent/config_flow.py
+++ b/custom_components/hass_agent/config_flow.py
@@ -76,14 +76,13 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         serial_number = payload["serial_number"]
 
-        _logger.debug(
-            "found device. Name: %s, Serial Number: %s", device_name, serial_number
-        )
+        _logger.debug("found device. Name: %s, Serial Number: %s", device_name, serial_number)
 
         self._data = {"device": payload["device"], "apis": payload["apis"]}
 
         for config in self._async_current_entries():
             if config.unique_id == serial_number:
+                _logger.debug("device %s, serial number: %s already configured, ignoring", device_name, serial_number)
                 return self.async_abort(reason="already_configured")
 
         await self.async_set_unique_id(serial_number)

--- a/custom_components/hass_agent/manifest.json
+++ b/custom_components/hass_agent/manifest.json
@@ -18,5 +18,6 @@
     "@DrR0X-glitch",
     "@amadeo-alex"
   ],
-  "iot_class": "local_push"
+  "iot_class": "local_push",
+  "loggers": ["custom_components.hass_agent"]
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "HASS.Agent 2 Integration",
+  "name": "HASS.Agent 2 Integration - Media Player & Notifications",
   "homeassistant": "2022.9",
   "render_readme": true
 }


### PR DESCRIPTION
This PR merges changes from various PRs created to both original and old forked repository.
In addition it includes change to fix the integration after Home Assistant 2024.5.X.

Note: not all changes in the PRs are active in this version - some service registration and device reload issues need to be solved first.

Related PRs:
https://github.com/LAB02-Research/HASS.Agent-Integration/pull/33
https://github.com/hass-agent/HASS.Agent-Integration-OLD/pull/3
https://github.com/hass-agent/HASS.Agent-Integration-OLD/pull/5
https://github.com/hass-agent/HASS.Agent-Integration-OLD/pull/6/files
https://github.com/hass-agent/HASS.Agent-Integration-OLD/pull/7