### PR TITLE
Fix: media player mute service call parameter not passed on to HASS.Agent

### DIFF
--- a/custom_components/hass_agent/media_player.py
+++ b/custom_components/hass_agent/media_player.py
@@ -249,7 +249,7 @@ class HassAgentMediaPlayerDevice(MediaPlayerEntity):
 
     async def async_mute_volume(self, mute):
         """Mute the volume"""
-        await self._send_command("mute")
+        await self._send_command(mute)
 
     async def async_media_play(self):
         """Send play command"""


### PR DESCRIPTION
This PR fixed mute service call skipping the user-provided value.
To work properly HASS.Agent will need to be at least version 2.1.1-beta2 that's going to be released soon.