### PR TITLE
Fix: mute service call parameter not passed to HASS.Agent

### DIFF
--- a/custom_components/hass_agent/media_player.py
+++ b/custom_components/hass_agent/media_player.py
@@ -249,7 +249,7 @@ class HassAgentMediaPlayerDevice(MediaPlayerEntity):
 
     async def async_mute_volume(self, mute):
         """Mute the volume"""
-        await self._send_command("mute")
+        await self._send_command(mute)
 
     async def async_media_play(self):
         """Send play command"""

--- a/custom_components/hass_agent/media_player.py
+++ b/custom_components/hass_agent/media_player.py
@@ -249,7 +249,7 @@ class HassAgentMediaPlayerDevice(MediaPlayerEntity):
 
     async def async_mute_volume(self, mute):
         """Mute the volume"""
-        await self._send_command(mute)
+        await self._send_command("mute", mute)
 
     async def async_media_play(self):
         """Send play command"""


### PR DESCRIPTION
This PR fixes media player mute service call to ignore user-provided parameter and always toggle.