### PR TITLE
Fix: missing player id argument while resolving media

### DIFF
--- a/custom_components/hass_agent/media_player.py
+++ b/custom_components/hass_agent/media_player.py
@@ -298,7 +298,7 @@ class HassAgentMediaPlayerDevice(MediaPlayerEntity):
             return
 
         if media_source.is_media_source_id(media_id):
-            play_item = await media_source.async_resolve_media(self.hass, media_id)
+            play_item = await media_source.async_resolve_media(self.hass, media_id, self.entity_id)
 
             # play_item returns a relative URL if it has to be resolved on the Home Assistant host
             # This call will turn it into a full URL


### PR DESCRIPTION
This PR fixes issue reported via https://github.com/hass-agent/HASS.Agent-Integration/issues/3
Thanks to @zachowj for reporting!