### PR TITLE
Update manifest.json version to 2.1.1

### DIFF
--- a/custom_components/hass_agent/manifest.json
+++ b/custom_components/hass_agent/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "hass_agent",
   "name": "HASS.Agent",
-  "version": "2.1.0-beta1",
+  "version": "2.1.1",
   "config_flow": true,
   "documentation": "https://github.com/hass-agent/HASS.Agent-Integration",
   "issue_tracker": "https://github.com/hass-agent/HASS.Agent-Integration/issues",


### PR DESCRIPTION
A simple version bump from version **2.1.0-beta1** to **2.1.1** 

![image](https://github.com/user-attachments/assets/5ab19a34-51ba-4f23-b4cc-61f10f48304c)

It was also reported in the issue #20