### PR TITLE
Fix: add handling of empty MQTT messages

### DIFF
--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -174,6 +174,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         @callback
         async def updated(message: ReceiveMessage):
+            if not message.payload:
+                _logger.debug("received empty update message on '%s', ignoring", message.topic)
+                return
+
             payload = json.loads(message.payload)
             cached = hass.data[DOMAIN][entry.entry_id]["apis"]
             apis = payload["apis"]

--- a/custom_components/hass_agent/config_flow.py
+++ b/custom_components/hass_agent/config_flow.py
@@ -69,6 +69,10 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_mqtt(self, discovery_info: MqttServiceInfo) -> FlowResult:
         """Handle a flow initialized by MQTT discovery."""
+        if not discovery_info.payload:
+            _logger.debug("received empty discovery message on '%s', ignoring", discovery_info.topic)
+            return self.async_abort(reason="not_supported")
+
         device_name = discovery_info.topic.split("hass.agent/devices/")[1]
 
         payload = json.loads(discovery_info.payload)

--- a/custom_components/hass_agent/config_flow.py
+++ b/custom_components/hass_agent/config_flow.py
@@ -20,9 +20,8 @@ _logger = logging.getLogger(__name__)
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    def __init__(self) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -66,7 +65,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> config_entries.OptionsFlow:
         """Create the options flow."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
     async def async_step_mqtt(self, discovery_info: MqttServiceInfo) -> FlowResult:
         """Handle a flow initialized by MQTT discovery."""


### PR DESCRIPTION
This PR fixes issues (resulting in Home Assistant system log errors) with empty device discovery messages.