### PR TITLE
Fix: added empty message check to media player logic

### DIFF
--- a/custom_components/hass_agent/media_player.py
+++ b/custom_components/hass_agent/media_player.py
@@ -94,6 +94,10 @@ class HassAgentMediaPlayerDevice(MediaPlayerEntity):
     @callback
     def updated(self, message: ReceiveMessage):
         """Updates the media player with new data from MQTT"""
+        if not message.payload:
+            _logger.debug("received empty update message on '%s', ignoring", message.topic)
+            return
+            
         payload = json.loads(message.payload)
 
         self._state = payload["state"].lower()


### PR DESCRIPTION
This PR adds check for empty MQTT message that can result in Home Assistant errors.