### PR TITLE
Fix: duplicate devices / device appearing as discovered even though already added

### DIFF
--- a/custom_components/hass_agent/config_flow.py
+++ b/custom_components/hass_agent/config_flow.py
@@ -114,18 +114,19 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     return requests.get(f"{url}/info", timeout=10)
 
                 response = await self.hass.async_add_executor_job(get_device_info)
+                response.raise_for_status()
                 response_json = response.json()
             except Exception:
                 errors["base"] = "cannot_connect"
+            else:
+                await self.async_set_unique_id(response_json["serial_number"])
+                self._abort_if_unique_id_configured()
 
-            await self.async_set_unique_id(response_json["serial_number"])
-            self._abort_if_unique_id_configured()
-
-            return self.async_create_entry(
-                title=response_json["device"]["name"],
-                data={CONF_URL: url},
-                options={CONF_DEFAULT_NOTIFICATION_TITLE: ATTR_TITLE_DEFAULT},
-            )
+                return self.async_create_entry(
+                    title=response_json["device"]["name"],
+                    data={CONF_URL: url},
+                    options={CONF_DEFAULT_NOTIFICATION_TITLE: ATTR_TITLE_DEFAULT},
+                )
 
         return self.async_show_form(
             step_id="local_api",

--- a/custom_components/hass_agent/config_flow.py
+++ b/custom_components/hass_agent/config_flow.py
@@ -83,13 +83,14 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         self._data = {"device": payload["device"], "apis": payload["apis"]}
 
-        for config in self._async_current_entries():
-            _logger.debug("device: %s, SN: %s, UID: %s", device_name, serial_number, config.unique_id) # TODO(Amadeo): remove
-            if config.unique_id == serial_number:
-                _logger.debug("device %s, serial number: %s already configured, ignoring", device_name, serial_number)
-                return self.async_abort(reason="already_configured")
+        #for config in self._async_current_entries():
+        #    _logger.debug("device: %s, SN: %s, UID: %s", device_name, serial_number, config.unique_id) # TODO(Amadeo): remove
+        #    if config.unique_id == serial_number:
+        #        _logger.debug("device %s, serial number: %s already configured, ignoring", device_name, serial_number)
+        #        return self.async_abort(reason="already_configured")
 
         await self.async_set_unique_id(serial_number)
+        self._abort_if_unique_id_configured()
 
         # "hass.agent/devices/#" is hardcoded in HASS.Agent's manifest
         assert discovery_info.subscribed_topic == "hass.agent/devices/#"
@@ -124,6 +125,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 response_json = response.json()
 
                 await self.async_set_unique_id(response_json["serial_number"])
+                self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(
                     title=response_json["device"]["name"],

--- a/custom_components/hass_agent/config_flow.py
+++ b/custom_components/hass_agent/config_flow.py
@@ -83,12 +83,6 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         self._data = {"device": payload["device"], "apis": payload["apis"]}
 
-        #for config in self._async_current_entries():
-        #    _logger.debug("device: %s, SN: %s, UID: %s", device_name, serial_number, config.unique_id) # TODO(Amadeo): remove
-        #    if config.unique_id == serial_number:
-        #        _logger.debug("device %s, serial number: %s already configured, ignoring", device_name, serial_number)
-        #        return self.async_abort(reason="already_configured")
-
         await self.async_set_unique_id(serial_number)
         self._abort_if_unique_id_configured()
 
@@ -116,25 +110,22 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             # serial number!
             try:
-
                 def get_device_info():
                     return requests.get(f"{url}/info", timeout=10)
 
                 response = await self.hass.async_add_executor_job(get_device_info)
-
                 response_json = response.json()
-
-                await self.async_set_unique_id(response_json["serial_number"])
-                self._abort_if_unique_id_configured()
-
-                return self.async_create_entry(
-                    title=response_json["device"]["name"],
-                    data={CONF_URL: url},
-                    options={CONF_DEFAULT_NOTIFICATION_TITLE: ATTR_TITLE_DEFAULT},
-                )
-
             except Exception:
                 errors["base"] = "cannot_connect"
+
+            await self.async_set_unique_id(response_json["serial_number"])
+            self._abort_if_unique_id_configured()
+
+            return self.async_create_entry(
+                title=response_json["device"]["name"],
+                data={CONF_URL: url},
+                options={CONF_DEFAULT_NOTIFICATION_TITLE: ATTR_TITLE_DEFAULT},
+            )
 
         return self.async_show_form(
             step_id="local_api",

--- a/custom_components/hass_agent/strings.json
+++ b/custom_components/hass_agent/strings.json
@@ -21,7 +21,8 @@
     },
     "abort": {
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
-      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
   "options": {
@@ -36,8 +37,8 @@
   },
   "device_automation": {
     "trigger_type": {
-      "notifications_mqtt": "When a notification with a specfic action has been pressed (MQTT)",
-      "notifications_event": "When a notification with a specfic action has been pressed (Event)"
+      "notifications_mqtt": "[%key:component::hass_agent::device_automation::trigger_type::notifications_mqtt%]",
+      "notifications_event": "[%key:component::hass_agent::device_automation::trigger_type::notifications_event%]"
     }
   }
 }

--- a/custom_components/hass_agent/translations/en.json
+++ b/custom_components/hass_agent/translations/en.json
@@ -2,10 +2,11 @@
     "config": {
         "flow_title": "{name}",
         "abort": {
-            "no_devices_found": "No devices found on the network"
+            "no_devices_found": "No devices found on the network.",
+            "already_configured": "This device is already configured."
         },
         "error": {
-            "cannot_connect": "Failed to connect"
+            "cannot_connect": "Failed to connect to HASS.Agent"
         },
         "step": {
             "confirm": {
@@ -34,8 +35,8 @@
     },
     "device_automation": {
         "trigger_type": {
-          "notifications_mqtt": "When a notification with a specfic action has been pressed (MQTT)",
-          "notifications_event": "When a notification with a specfic action has been pressed (Event)"
+          "notifications_mqtt": "When a notification with a specific action has been pressed (MQTT)",
+          "notifications_event": "When a notification with a specific action has been pressed (Event)"
         }
     }
 }


### PR DESCRIPTION
This PR fixes issue where devices would be discovered more than once, even though the unique id (serial number) did not change.