### PR TITLE
Fix: handling of devices' media player without original name

### DIFF
--- a/custom_components/hass_agent/media_player.py
+++ b/custom_components/hass_agent/media_player.py
@@ -67,7 +67,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     if device is None:
         return False
 
-    async_add_entities([HassAgentMediaPlayerDevice(entry.unique_id, entry.entry_id, device, entry.data[CONF_ORIGINAL_DEVICE_NAME])])
+    original_device_name = entry.data.get(CONF_ORIGINAL_DEVICE_NAME, device.name)
+
+    async_add_entities([HassAgentMediaPlayerDevice(entry.unique_id, entry.entry_id, device, original_device_name)])
 
     return True
 


### PR DESCRIPTION
Potential quick fix for:
```
Logger: homeassistant.components.media_player
Source: helpers/entity_platform.py:451
integration: Media player (documentation, issues)
First occurred: 6:26:20 AM (1 occurrence)
Last logged: 6:26:20 AM

Error while setting up hass_agent platform for media_player: 'original_device_name'
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 451, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/config/custom_components/hass_agent/media_player.py", line 70, in async_setup_entry
    async_add_entities([HassAgentMediaPlayerDevice(entry.unique_id, entry.entry_id, device, entry.data[CONF_ORIGINAL_DEVICE_NAME])])
                                                                                            ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'original_device_name'
```
Thanks to @Anto79-ops for reporting!