### PR TITLE
Fix restart-required infinite loop from stale retained MQTT discovery

### DIFF
--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -33,6 +33,8 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify
 
+from homeassistant.helpers import issue_registry as ir
+
 from .const import DOMAIN, CONF_ORIGINAL_DEVICE_NAME, CONF_DEVICE_NAME
 
 PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
@@ -116,6 +118,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up HASS.Agent from a config entry."""
 
     _logger.debug("setting up device from config entry: %s [%s]", entry.title, entry.unique_id)
+
+    # NOTE(Amadeo): sweep leftover restart_required issues from renamed devices
+    # that never got dismissed — keeps the repairs list clean
+    for d, i in list(ir.async_get(hass).issues):
+        if d == DOMAIN:
+            ir.async_delete_issue(hass, DOMAIN, i)
 
     hass.data.setdefault(DOMAIN, {})
 

--- a/custom_components/hass_agent/config_flow.py
+++ b/custom_components/hass_agent/config_flow.py
@@ -14,7 +14,11 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_SSL, CONF_URL
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 
 from .const import DOMAIN, CONF_DEFAULT_NOTIFICATION_TITLE, CONF_ORIGINAL_DEVICE_NAME, CONF_DEVICE_NAME
 
@@ -86,7 +90,11 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self._data[CONF_ORIGINAL_DEVICE_NAME] = device_name
 
         if entry:
-            reload_required = device_name != entry.title
+            old_title = entry.title
+
+            # delete stale issue from the old name first so they dont pile up
+            if device_name != old_title:
+                async_delete_issue(self.hass, DOMAIN, f"restart_required_{old_title}")
 
             self.hass.config_entries.async_update_entry(
                 entry,
@@ -94,13 +102,13 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 data={**entry.data, **self._data},
             )
 
-            if reload_required:
+            if device_name != old_title:
                 self.hass.config_entries.async_schedule_reload(entry.entry_id)
 
                 async_create_issue(
-                    hass=self.hass,
-                    domain=DOMAIN,
-                    issue_id=f"restart_required_{device_name}",
+                    self.hass,
+                    DOMAIN,
+                    f"restart_required_{device_name}",
                     data={CONF_DEVICE_NAME: device_name},
                     is_fixable=True,
                     severity=IssueSeverity.WARNING,
@@ -109,6 +117,10 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         "name": device_name,
                     },
                 )
+            else:
+                # no rename happened, but delete the issue anyway
+                # in case one was left behind by a previous rename
+                async_delete_issue(self.hass, DOMAIN, f"restart_required_{device_name}")
 
         self._abort_if_unique_id_configured()
 

--- a/custom_components/hass_agent/repairs.py
+++ b/custom_components/hass_agent/repairs.py
@@ -7,6 +7,7 @@ from typing import Any
 from homeassistant import data_entry_flow
 from homeassistant.components.repairs import RepairsFlow
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 import voluptuous as vol
 
 from .const import DOMAIN, CONF_DEVICE_NAME
@@ -27,6 +28,7 @@ class RestartRequiredFixFlow(RepairsFlow):
     async def async_step_confirm_restart(self, user_input: dict[str, str] | None = None) -> data_entry_flow.FlowResult:
         """Handle the confirm step of a fix flow."""
         if user_input is not None:
+            ir.async_delete_issue(self.hass, DOMAIN, self.issue_id)
             await self.hass.services.async_call("homeassistant", "restart")
             return self.async_create_entry(title="", data={})
 


### PR DESCRIPTION
Fixes https://github.com/hass-agent/HASS.Agent-Integration/issues/63

Three fixes to break the restart-required infinite loop:

- **config_flow.py**: delete stale issue from old device name before creating a new one on rename; also delete the issue on name-match discovery (safety net for lingering issues)
- **repairs.py**: dismiss the issue immediately when user clicks "Restart" in the fix flow, before calling homeassistant.restart
- **__init__.py**: sweep all leftover `hass_agent` issues on startup so renamed devices that never got dismissed don't pile up forever