### PR TITLE
Add a notify entity next to the notify service

### DIFF
--- a/custom_components/hass_agent/__init__.py
+++ b/custom_components/hass_agent/__init__.py
@@ -102,12 +102,18 @@ async def handle_apis_changed(hass: HomeAssistant, entry: ConfigEntry, apis):
                     {},
                 )
             )
+
+            # the notify service is loaded through discovery, the notify entity through the config entry
+            await hass.config_entries.async_forward_entry_setups(entry, [Platform.NOTIFY])
+
             hass.data[DOMAIN][entry.entry_id]["loaded"]["notifications"] = True
         else:
             if is_notifications_loaded:
-                # _logger.debug("unloading notifications for device: %s [%s]", device.name, entry.unique_id)
-                # await hass.config_entries.async_unload_platforms(entry, [Platform.NOTIFY])
-                # NOTE(Amadeo): disabled due to "ValueError: Config entry was never loaded!" error
+                _logger.debug("unloading notifications for device: %s [%s]", device.name, entry.unique_id)
+
+                # only the notify entity can be unloaded, the discovery loaded notify service can't
+                # ("ValueError: Config entry was never loaded!")
+                await hass.config_entries.async_forward_entry_unload(entry, Platform.NOTIFY)
 
                 hass.data[DOMAIN][entry.entry_id]["loaded"]["notifications"] = False
 
@@ -195,18 +201,18 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _logger.debug("unloading device: %s [%s]", entry.title, entry.unique_id)
 
-    # known issue: notify does not always unload
-    # NOTE(Amadeo): unloading NOTIFY platform always fails, same happens for example for https://github.com/home-assistant/core/blob/dd7f7be6adee76f2add98dcca8d3ff87bceabf70/homeassistant/components/nfandroidtv/__init__.py
+    # known issue: the notify service does not unload, only the notify entity does
+    # NOTE(Amadeo): unloading a discovery loaded NOTIFY platform always fails, same happens for example for https://github.com/home-assistant/core/blob/dd7f7be6adee76f2add98dcca8d3ff87bceabf70/homeassistant/components/nfandroidtv/__init__.py
     loaded = hass.data[DOMAIN][entry.entry_id].get("loaded", None)
 
     if loaded is not None:
         notifications = loaded.get("notifications", False)
         media_player = loaded.get("media_player", False)
 
-        # if notifications:
-        #     if unload_ok := await hass.config_entries.async_unload_platforms(entry, [Platform.NOTIFY]):
-        #         _logger.debug("unloaded notifications for: %s [%s]", entry.title, entry.unique_id)
-        # NOTE(Amadeo): disabled due to "ValueError: Config entry was never loaded!" error
+        if notifications:
+            # only unloads the notify entity, the discovery loaded notify service stays behind
+            if unload_ok := await hass.config_entries.async_unload_platforms(entry, [Platform.NOTIFY]):
+                _logger.debug("unloaded notifications for: %s [%s]", entry.title, entry.unique_id)
 
         if media_player:
             if unload_ok := await hass.config_entries.async_unload_platforms(entry, [Platform.MEDIA_PLAYER]):

--- a/custom_components/hass_agent/notify.py
+++ b/custom_components/hass_agent/notify.py
@@ -10,11 +10,19 @@ import re
 
 from homeassistant.components.notify import (
     ATTR_TITLE,
+    ATTR_TITLE_DEFAULT,
     ATTR_DATA,
     BaseNotificationService,
+    NotifyEntity,
+    NotifyEntityFeature,
 )
 
 from homeassistant.components import media_source, mqtt
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
@@ -27,11 +35,135 @@ from homeassistant.const import (
 from .const import (
     CONF_DEFAULT_NOTIFICATION_TITLE,
     CONF_DEVICE_NAME,
+    DOMAIN,
 )
 
 _logger = logging.getLogger(__name__)
 
 CAMERA_PROXY_REGEX = re.compile(r"\/api\/camera_proxy\/camera\.(.*)")
+
+
+async def async_resolve_image(hass: HomeAssistant, image: str):
+    """Resolve an image to an url HASS.Agent can download it from, if needed"""
+
+    camera_proxy_match = CAMERA_PROXY_REGEX.match(image)
+
+    if camera_proxy_match is not None:
+        camera = hass.states.get(f"camera.{camera_proxy_match.group(1)}")
+
+        if camera is not None:
+            external_url = None
+            with suppress(NoURLAvailableError):  # external_url not configured
+                external_url = get_url(hass, allow_internal=False)
+
+            if external_url is not None:
+                access_token = camera.attributes["access_token"]
+                return f"{external_url}{image}?token={access_token}"
+
+    elif media_source.is_media_source_id(image):
+        sourced_media = await media_source.async_resolve_media(hass, image)
+        return media_source.async_process_play_media_url(hass, sourced_media.url)
+
+    return None
+
+
+async def async_build_payload(hass: HomeAssistant, message: str, title: str, data):
+    """Build the notification payload HASS.Agent expects"""
+
+    if data is None:
+        data = dict()
+
+    image = data.get("image", None)
+
+    if image is not None:
+        new_url = await async_resolve_image(hass, image)
+
+        if new_url is not None:
+            data.update({"image": new_url})
+
+    return {"message": message, "title": title, "data": data}
+
+
+async def async_send_payload(hass: HomeAssistant, entry: ConfigEntry, device_name: str, payload):
+    """Send the notification payload to the device, through MQTT or its local API"""
+
+    _logger.debug("Sending notification")
+
+    url = entry.data.get(CONF_URL, None)
+
+    if url is None:
+        await mqtt.async_publish(
+            hass,
+            f"hass.agent/notifications/{device_name}",
+            json.dumps(payload),
+        )
+    else:
+        try:
+
+            def send_request(url, data):
+                """Sends the json request"""
+                return requests.post(url, json=data, timeout=10)
+
+            response = await hass.async_add_executor_job(send_request, f"{url}/notify", payload)
+
+            _logger.debug("Checking result")
+
+            if response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
+                _logger.error(
+                    "Server error. Response %d: %s",
+                    response.status_code,
+                    response.reason,
+                )
+            elif response.status_code == HTTPStatus.BAD_REQUEST:
+                _logger.error(
+                    "Client error (bad request). Response %d: %s",
+                    response.status_code,
+                    response.reason,
+                )
+            elif response.status_code == HTTPStatus.NOT_FOUND:
+                _logger.debug(
+                    "Server error (not found). Response %d: %s",
+                    response.status_code,
+                    response.reason,
+                )
+            elif response.status_code == HTTPStatus.METHOD_NOT_ALLOWED:
+                _logger.error(
+                    "Server error (method not allowed). Response %d",
+                    response.status_code,
+                )
+            elif response.status_code == HTTPStatus.REQUEST_TIMEOUT:
+                _logger.debug(
+                    "Server error (request timeout). Response %d: %s",
+                    response.status_code,
+                    response.reason,
+                )
+            elif response.status_code == HTTPStatus.NOT_IMPLEMENTED:
+                _logger.error(
+                    "Server error (not implemented). Response %d: %s",
+                    response.status_code,
+                    response.reason,
+                )
+            elif response.status_code == HTTPStatus.SERVICE_UNAVAILABLE:
+                _logger.error(
+                    "Server error (service unavailable). Response %d",
+                    response.status_code,
+                )
+            elif response.status_code == HTTPStatus.GATEWAY_TIMEOUT:
+                _logger.error(
+                    "Network error (gateway timeout). Response %d: %s",
+                    response.status_code,
+                    response.reason,
+                )
+            elif response.status_code == HTTPStatus.OK:
+                _logger.debug(
+                    "Success. Response %d: %s",
+                    response.status_code,
+                    response.reason,
+                )
+            else:
+                _logger.debug("Unknown response %d: %s", response.status_code, response.reason)
+        except Exception as ex:
+            _logger.debug("Error sending message: %s", ex)
 
 
 def get_service(hass, config, discovery_info=None):
@@ -45,6 +177,20 @@ def get_service(hass, config, discovery_info=None):
         discovery_info[CONF_NAME],
         entry_id,
     )
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> bool:
+    """Set up the notify entity from a config entry."""
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.unique_id)})
+
+    if device is None:
+        return False
+
+    async_add_entities([HassAgentNotifyEntity(entry.unique_id, entry.entry_id, device)])
+
+    return True
 
 
 class HassAgentNotificationService(BaseNotificationService):
@@ -65,114 +211,60 @@ class HassAgentNotificationService(BaseNotificationService):
 
         title = kwargs.get(ATTR_TITLE, entry.options[CONF_DEFAULT_NOTIFICATION_TITLE])
 
-        data = kwargs.get(ATTR_DATA, None)
+        payload = await async_build_payload(self.hass, message, title, kwargs.get(ATTR_DATA, None))
 
-        if data is None:
-            data = dict()
+        await async_send_payload(self.hass, entry, self._device_name, payload)
 
-        image = data.get("image", None)
 
-        if image is not None:
-            new_url = None
+class HassAgentNotifyEntity(NotifyEntity):
+    """Implementation of the HASS.Agent notify entity
 
-            camera_proxy_match = CAMERA_PROXY_REGEX.match(image)
+    Note: the send_message action only carries a message and a title, so images,
+          actions and inputs remain available through the notify service only.
+    """
 
-            if camera_proxy_match is not None:
-                camera = self.hass.states.get(f"camera.{camera_proxy_match.group(1)}")
+    _attr_has_entity_name = True
+    _attr_name = "Notifications"
+    _attr_icon = "mdi:bell"
+    _attr_supported_features = NotifyEntityFeature.TITLE
 
-                if camera is not None:
-                    external_url = None
-                    with suppress(NoURLAvailableError):  # external_url not configured
-                        external_url = get_url(self.hass, allow_internal=False)
+    def __init__(self, unique_id, entry_id, device: dr.DeviceEntry):
+        """Initialize the entity."""
+        self._entry_id = entry_id
+        self._device_identifier = unique_id
+        self._attr_unique_id = f"notify_{unique_id}"
+        self._attr_device_info = {
+            "identifiers": device.identifiers,
+            "name": device.name,
+            "manufacturer": device.manufacturer,
+            "model": device.model,
+            "sw_version": device.sw_version,
+        }
 
-                    if external_url is not None:
-                        access_token = camera.attributes["access_token"]
-                        new_url = f"{external_url}{image}?token={access_token}"
+    @property
+    def _device_name(self):
+        """Return the device's current name, which its notification topic is based on"""
 
-            elif media_source.is_media_source_id(image):
-                sourced_media = await media_source.async_resolve_media(self.hass, image)
-                sourced_media = media_source.async_process_play_media_url(self.hass, sourced_media.url)
-                new_url = sourced_media
+        device_registry = dr.async_get(self.hass)
+        device = device_registry.async_get_device(identifiers={(DOMAIN, self._device_identifier)})
 
-            if new_url is not None:
-                data.update({"image": new_url})
+        return device.name if device is not None else None
 
-        payload = {"message": message, "title": title, "data": data}
+    async def async_send_message(self, message: str, title: str | None = None) -> None:
+        """Send the message to the device."""
+        _logger.debug("Preparing notification")
 
-        _logger.debug("Sending notification")
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
 
-        url = entry.data.get(CONF_URL, None)
+        if title is None:
+            title = entry.options.get(CONF_DEFAULT_NOTIFICATION_TITLE, ATTR_TITLE_DEFAULT)
 
-        if url is None:
-            await mqtt.async_publish(
-                self.hass,
-                f"hass.agent/notifications/{self._device_name}",
-                json.dumps(payload),
-            )
-        else:
-            try:
+        device_name = self._device_name
 
-                def send_request(url, data):
-                    """Sends the json request"""
-                    return requests.post(url, json=data, timeout=10)
+        if device_name is None:
+            _logger.error("Device of '%s' is gone, dropping notification", self.entity_id)
+            return
 
-                response = await self.hass.async_add_executor_job(send_request, f"{entry.data[CONF_URL]}/notify", payload)
+        payload = await async_build_payload(self.hass, message, title, None)
 
-                _logger.debug("Checking result")
-
-                if response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
-                    _logger.error(
-                        "Server error. Response %d: %s",
-                        response.status_code,
-                        response.reason,
-                    )
-                elif response.status_code == HTTPStatus.BAD_REQUEST:
-                    _logger.error(
-                        "Client error (bad request). Response %d: %s",
-                        response.status_code,
-                        response.reason,
-                    )
-                elif response.status_code == HTTPStatus.NOT_FOUND:
-                    _logger.debug(
-                        "Server error (not found). Response %d: %s",
-                        response.status_code,
-                        response.reason,
-                    )
-                elif response.status_code == HTTPStatus.METHOD_NOT_ALLOWED:
-                    _logger.error(
-                        "Server error (method not allowed). Response %d",
-                        response.status_code,
-                    )
-                elif response.status_code == HTTPStatus.REQUEST_TIMEOUT:
-                    _logger.debug(
-                        "Server error (request timeout). Response %d: %s",
-                        response.status_code,
-                        response.reason,
-                    )
-                elif response.status_code == HTTPStatus.NOT_IMPLEMENTED:
-                    _logger.error(
-                        "Server error (not implemented). Response %d: %s",
-                        response.status_code,
-                        response.reason,
-                    )
-                elif response.status_code == HTTPStatus.SERVICE_UNAVAILABLE:
-                    _logger.error(
-                        "Server error (service unavailable). Response %d",
-                        response.status_code,
-                    )
-                elif response.status_code == HTTPStatus.GATEWAY_TIMEOUT:
-                    _logger.error(
-                        "Network error (gateway timeout). Response %d: %s",
-                        response.status_code,
-                        response.reason,
-                    )
-                elif response.status_code == HTTPStatus.OK:
-                    _logger.debug(
-                        "Success. Response %d: %s",
-                        response.status_code,
-                        response.reason,
-                    )
-                else:
-                    _logger.debug("Unknown response %d: %s", response.status_code, response.reason)
-            except Exception as ex:
-                _logger.debug("Error sending message: %s", ex)
+        await async_send_payload(self.hass, entry, device_name, payload)


### PR DESCRIPTION
Only a notify service was registered, so there was no notify entity to use with the notify.send_message action.

Add a notify entity per device, loaded through the config entry when the device reports the notifications api, next to the discovery loaded notify service. Since a notify entity only carries a message and a title, images, actions and inputs stay available through the service only.

The payload building and sending is shared between both, so the entity supports the local API as well and resolves camera proxy and media source images the same way. Without a title, the configured default notification title is used.


Claude-Session: https://claude.ai/code/session_01QDaRJhCXG7uUTtDERCoHFZ